### PR TITLE
Separate calc tumors from mass tumors

### DIFF
--- a/doc/data_preparation.md
+++ b/doc/data_preparation.md
@@ -2,7 +2,12 @@
 
 This document outlines the steps for preparing mammographic images before feeding them into a machine learning model. These steps include converting DICOM files, normalizing pixel values, resizing images, enhancing contrast, applying data augmentation, and preparing data for segmentation tasks.
 
-To prepare the data, you will need to run the [`src.prepare_data_detection`](../src/prepare_data_detection.py) and [`src.prepare_data_segmentation`](../src/prepare_data_segmentation.py) modules sequentially. Ensure that the input directory for the second module is set to the output directory of the first module. This guarantees that the validation set is created and contrast adjustment is applied to each image before creating the dataset for the segmentation task.
+To prepare the data, simply run the [`scripts/prepare_data.sh`](../scripts/prepare_data.sh) script. To do so, follow the steps below. Make sure to execute these commands from the root directory of the project. The script will only succeed if you have placed your dataset in the `data/cbis-ddsm` directory.
+
+```bash
+chmod +x scripts/prepare_data.sh
+./scripts/prepare_data.sh
+```
 
 For training, use the `CbisDdsmDataModule` class from [`src.data_module`](../src/data_module.py). This will ensure that all images are augmented and transformed to a consistent size.
 

--- a/scripts/prepare_data.sh
+++ b/scripts/prepare_data.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+python -m scripts.prepare_data_detection --input-directory data/cbis-ddsm
+python -m scripts.prepare_data_segmentation --input-folder data/cbis-ddsm-detec

--- a/scripts/prepare_data_detection.py
+++ b/scripts/prepare_data_detection.py
@@ -89,6 +89,16 @@ def list_image_paths(root_dir):
     return img_paths
 
 
+def has_mask_of_type(img_name, tumor_type, msk_dir):
+    assert tumor_type in ["calc", "mass"]
+    for mask_name in os.listdir(msk_dir):
+        mask_base_name = os.path.splitext(mask_name)[0]
+        mask_prefix = mask_base_name.rsplit("_", 6)[0]
+        if f"_{tumor_type}_" in mask_base_name and mask_prefix in img_name:
+            return True
+    return False
+
+
 def prepare_dir(in_dir, subdir, out_dir):
     in_img_dir = os.path.join(in_dir, subdir, "images")
     in_msk_dir = os.path.join(in_dir, subdir, "masks")
@@ -127,18 +137,20 @@ def prepare_dir(in_dir, subdir, out_dir):
 
         image = Image.fromarray(image)
 
-        out_calc_img_path = os.path.join(out_calc_img_dir, img_name)
-        image.save(out_calc_img_path)
+        if has_mask_of_type(img_name, "calc", in_msk_dir):
+            out_calc_img_path = os.path.join(out_calc_img_dir, img_name)
+            image.save(out_calc_img_path)
 
-        out_mass_img_path = os.path.join(out_mass_img_dir, img_name)
-        image.save(out_mass_img_path)
+        if has_mask_of_type(img_name, "mass", in_msk_dir):
+            out_mass_img_path = os.path.join(out_mass_img_dir, img_name)
+            image.save(out_mass_img_path)
 
         successful_image_basenames.append(os.path.splitext(img_name)[0])
 
         print(f"INFO: Processed {i}/{img_cnt} images", end="\r", flush=True)
 
     # Copy mask files into a directory the CbisDdsmDataset will find
-    print(f"INFO: Copying masks from '{in_msk_dir}' to '{out_calc_msk_dir}'")
+    print(f"INFO: Copying masks from '{in_msk_dir}' to '{out_calc_msk_dir}' and '{out_mass_msk_dir}'")
 
     for mask_name in os.listdir(in_msk_dir):
         mask_base_name = os.path.splitext(mask_name)[0]

--- a/scripts/prepare_data_detection.py
+++ b/scripts/prepare_data_detection.py
@@ -93,7 +93,7 @@ def has_mask_of_type(img_name, tumor_type, msk_dir):
     assert tumor_type in ["calc", "mass"]
     for mask_name in os.listdir(msk_dir):
         mask_base_name = os.path.splitext(mask_name)[0]
-        mask_prefix = mask_base_name.rsplit("_", 6)[0]
+        mask_prefix = mask_base_name.rsplit("_", 2)[0]
         if f"_{tumor_type}_" in mask_base_name and mask_prefix in img_name:
             return True
     return False

--- a/scripts/prepare_data_detection.py
+++ b/scripts/prepare_data_detection.py
@@ -92,14 +92,18 @@ def list_image_paths(root_dir):
 def prepare_dir(in_dir, subdir, out_dir):
     in_img_dir = os.path.join(in_dir, subdir, "images")
     in_msk_dir = os.path.join(in_dir, subdir, "masks")
-    out_img_dir = os.path.join(out_dir, subdir, "images")
-    out_msk_dir = os.path.join(out_dir, subdir, "masks")
+    out_calc_img_dir = os.path.join(out_dir, subdir, "calc", "images")
+    out_calc_msk_dir = os.path.join(out_dir, subdir, "calc", "masks")
+    out_mass_img_dir = os.path.join(out_dir, subdir, "mass", "images")
+    out_mass_msk_dir = os.path.join(out_dir, subdir, "mass", "masks")
 
     assert os.path.exists(in_img_dir)
     assert os.path.exists(in_msk_dir)
 
-    os.makedirs(out_img_dir, exist_ok=True)
-    os.makedirs(out_msk_dir, exist_ok=True)
+    os.makedirs(out_calc_img_dir, exist_ok=True)
+    os.makedirs(out_calc_msk_dir, exist_ok=True)
+    os.makedirs(out_mass_img_dir, exist_ok=True)
+    os.makedirs(out_mass_msk_dir, exist_ok=True)
 
     in_img_names = os.listdir(in_img_dir)
     img_cnt = len(in_img_names)
@@ -123,22 +127,29 @@ def prepare_dir(in_dir, subdir, out_dir):
 
         image = Image.fromarray(image)
 
-        out_img_path = os.path.join(out_img_dir, img_name)
-        image.save(out_img_path)
+        out_calc_img_path = os.path.join(out_calc_img_dir, img_name)
+        image.save(out_calc_img_path)
+
+        out_mass_img_path = os.path.join(out_mass_img_dir, img_name)
+        image.save(out_mass_img_path)
 
         successful_image_basenames.append(os.path.splitext(img_name)[0])
 
         print(f"INFO: Processed {i}/{img_cnt} images", end="\r", flush=True)
 
     # Copy mask files into a directory the CbisDdsmDataset will find
-    print(f"INFO: Copying masks from '{in_msk_dir}' to '{out_msk_dir}'")
+    print(f"INFO: Copying masks from '{in_msk_dir}' to '{out_calc_msk_dir}'")
 
     for mask_name in os.listdir(in_msk_dir):
         mask_base_name = os.path.splitext(mask_name)[0]
         mask_prefix = mask_base_name.rsplit("_", 2)[0]
         if mask_prefix in successful_image_basenames:
             in_msk_path = os.path.join(in_msk_dir, mask_name)
-            out_msk_path = os.path.join(out_msk_dir, mask_name)
+            # Determine the appropriate directory for each mask
+            if "_calc_" in mask_name:
+                out_msk_path = os.path.join(out_calc_msk_dir, mask_name)
+            else:
+                out_msk_path = os.path.join(out_mass_msk_dir, mask_name)
             shutil.copy(in_msk_path, out_msk_path)
 
     print(f"INFO: Finished processing '{in_dir}'")

--- a/scripts/prepare_data_detection.py
+++ b/scripts/prepare_data_detection.py
@@ -164,7 +164,7 @@ def prepare_dir(in_dir, subdir, out_dir):
                 out_msk_path = os.path.join(out_mass_msk_dir, mask_name)
             shutil.copy(in_msk_path, out_msk_path)
 
-    print(f"INFO: Finished processing '{in_dir}'")
+    print(f"INFO: Finished processing '{os.path.join(in_dir, subdir)}'")
 
 
 def prepare_dataset(in_dir):

--- a/scripts/prepare_data_segmentation.py
+++ b/scripts/prepare_data_segmentation.py
@@ -123,7 +123,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    output_folder = f"{args.input_folder}-segme"
+    output_folder = f"{args.input_folder.rsplit("-", 1)[0]}-segme"
 
     if not os.path.exists(args.input_folder):
         print(f"Error: Input folder '{args.input_folder}' does not exist.")

--- a/scripts/prepare_data_segmentation.py
+++ b/scripts/prepare_data_segmentation.py
@@ -35,18 +35,24 @@ def crop_image_to_mask(image, mask, min_padding=50, max_padding=300):
     x_min, x_max = x_indices.min(), x_indices.max()
     y_min, y_max = y_indices.min(), y_indices.max()
 
-    # Apply padding
-    paddings = [np.random.randint(min_padding, max_padding) for _ in range(4)]
-    x_min = max(x_min - paddings[0], 0)
-    x_max = min(x_max + paddings[1], image.width)
-    y_min = max(y_min - paddings[2], 0)
-    y_max = min(y_max + paddings[3], image.height)
+    cropped_pairs = []
 
-    # Crop the image and mask
-    cropped_image = image.crop((x_min, y_min, x_max, y_max))
-    cropped_mask = mask.crop((x_min, y_min, x_max, y_max))
+    # Create five differently cropped version
+    for _ in range(5):
+        # Apply padding
+        paddings = [np.random.randint(min_padding, max_padding) for _ in range(4)]
+        x_min = max(x_min - paddings[0], 0)
+        x_max = min(x_max + paddings[1], image.width)
+        y_min = max(y_min - paddings[2], 0)
+        y_max = min(y_max + paddings[3], image.height)
 
-    return cropped_image, cropped_mask
+        # Crop the image and mask
+        cropped_image = image.crop((x_min, y_min, x_max, y_max))
+        cropped_mask = mask.crop((x_min, y_min, x_max, y_max))
+
+        cropped_pairs.append((cropped_image, cropped_mask))
+
+    return cropped_pairs
 
 
 def process_dataset(input_folder, output_folder, dataset_type):
@@ -86,19 +92,16 @@ def process_dataset(input_folder, output_folder, dataset_type):
 
         # Process each mask
         for i, mask in enumerate(masks):
-            cropped_image, cropped_mask = crop_image_to_mask(image, mask)
-
-            # Save cropped images and masks
-            cropped_image.save(
-                os.path.join(
-                    output_image_folder, f"{os.path.splitext(img_file)[0]}_{i}.png"
+            cropped_pairs = crop_image_to_mask(image, mask)
+            for  j, (cropped_image, cropped_mask) in enumerate(cropped_pairs):
+                base_name = f"{os.path.splitext(img_file)[0]}_{i}_{j}"
+                # Save cropped images and masks
+                cropped_image.save(
+                    os.path.join(output_image_folder, f"{base_name}.png")
                 )
-            )
-            cropped_mask.save(
-                os.path.join(
-                    output_mask_folder, f"{os.path.splitext(img_file)[0]}_mask_{i}.png"
+                cropped_mask.save(
+                    os.path.join(output_mask_folder, f"{base_name}_mask.png")
                 )
-            )
 
         # Print progress update
         print(

--- a/scripts/prepare_data_segmentation.py
+++ b/scripts/prepare_data_segmentation.py
@@ -2,7 +2,7 @@
 Prepares the dataset for segmentation by processing image and mask files.
 
 To execute the script, use the following command:
-    `python -m src.prepare_data_segmentation --input-directory <path_to_input_dir>`
+    `python -m src.prepare_data_segmentation --input-folder <path_to_input_dir>`
 
 Args:
     input_folder (str): Path to the directory containing the `train` and `test` subdirectories,
@@ -113,7 +113,7 @@ def process_dataset(input_folder, output_folder, dataset_type):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Crop images based on mask regions.")
     parser.add_argument(
-        "input_folder",
+        "--input-folder",
         type=str,
         help="Path to the input data folder (e.g., '../data/cbis-ddsm')",
     )
@@ -127,4 +127,6 @@ if __name__ == "__main__":
         sys.exit(1)
 
     for dataset in ["train", "test", "val"]:
-        process_dataset(args.input_folder, output_folder, dataset)
+        for type in ["calc", "mass"]:
+            dt = os.path.join(dataset, type)
+            process_dataset(args.input_folder, output_folder, dt)

--- a/src/data_module.py
+++ b/src/data_module.py
@@ -53,12 +53,9 @@ class CbisDdsmDataset(Dataset):
                 mask = np.array(mask)
                 masks.append(mask)
 
-        # Ensure that a black mask of the same size as the image is created
-        image_width, image_height = image.size
-        combined_mask = np.zeros((image_height, image_width), dtype=np.uint8)
+        assert len(masks) > 0
+        combined_mask = np.zeros_like(masks[0])
         for mask in masks:
-            height, width = mask.shape
-            assert width == image_width and height == image_height
             combined_mask = np.logical_or(combined_mask, mask)
 
         combined_mask = combined_mask.astype(np.uint8)

--- a/src/mock_model.py
+++ b/src/mock_model.py
@@ -40,6 +40,7 @@ class MockModel(pl.LightningModule):
 if __name__ == "__main__":
     data_module = dm.CbisDdsmDataModule(
         root_dir="data/cbis-ddsm-detec",
+        tumor_type="calc",
         batch_size=5,
         num_workers=7,
     )


### PR DESCRIPTION
Sampled tumors should reflect the same distribution of "calc" and "mass" tumor types as the original dataset, as long as `random.sample` is truly random.

Also added multiple crops for each image.

Data preparation runs for a long time. I suggest you run it, if you think that I have came up with an acceptable solution for data preparation.